### PR TITLE
sort linker input files

### DIFF
--- a/fbreader/Makefile
+++ b/fbreader/Makefile
@@ -22,7 +22,7 @@ all: .resources
 		fi; \
 	done;
 	@echo -n 'Linking $(TARGET) ...'
-	@$(LD) $(LDFLAGS) -o $(TARGET) `find src -name *.o` -L$(ROOTDIR)/zlibrary/text $(TEXT_LIBS) $(CORE_LIBS) -lsqlite3
+	@$(LD) $(LDFLAGS) -o $(TARGET) `find src -name *.o | LC_ALL=C sort` -L$(ROOTDIR)/zlibrary/text $(TEXT_LIBS) $(CORE_LIBS) -lsqlite3
 	@echo ' OK'
 
 FBSHAREDIR = $(DESTDIR)$(SHAREDIR)/FBReader


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.

Setting LC_ALL is needed because locales influence how sorting happens.

This was originally filed at https://github.com/geometer/FBReader/pull/295 but that seems orphaned.